### PR TITLE
fix: allow jumping to specific frame

### DIFF
--- a/ios/GifPlayerViewComponent.swift
+++ b/ios/GifPlayerViewComponent.swift
@@ -187,9 +187,13 @@ public class GifPlayerViewComponent: UIImageView {
         displayLink?.isPaused = true
         handleStop()
     }
-    
+
     @objc public func jumpToFrame(frameNumber: Int){
-        currentIndex = 0;
+        guard frameNumber >= 0 && frameNumber < gifImages.count else {
+            return
+        }
+
+        currentIndex = frameNumber
         updateFrame()
     }
 


### PR DESCRIPTION
## Summary
- allow jumpToFrame to display a requested frame
- guard against invalid frame numbers

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bdd67eba88326a1d99dbb379372f4